### PR TITLE
Plattform 2371: fix node installasjon og bygg playwright runner hver natt

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,0 +1,39 @@
+name: Nightly build
+
+on:
+  workflow_dispatch:
+  schedule:
+    # once every day
+    - cron: '0 0 * * *'
+
+env:
+  REGISTRY_URL: ghcr.io/domstolene/openshift-actions-runners
+
+  PLAYWRIGHT_IMG_NAME: playwright-runner
+  PLAYWRIGHT_IMG_DIR: playwright
+  IMG_TAGS: latest
+
+jobs:
+  update_images:
+    name: Update images
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push playwright image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.PLAYWRIGHT_IMG_DIR }}
+          file: ${{ env.PLAYWRIGHT_IMG_DIR }}/Containerfile
+          push: true
+          tags: ${{ env.REGISTRY_URL }}/${{ env.PLAYWRIGHT_IMG_NAME }}:${{ env.IMG_TAGS }}

--- a/playwright/Containerfile
+++ b/playwright/Containerfile
@@ -4,6 +4,9 @@ FROM $BASE_IMG AS runner
 # Switch to root user to install dependencies
 USER root
 
+# update nodesources ref: https://github.com/nodesource/distributions/issues/1747
+RUN curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -
+    
 # Install Node.js and npm
 RUN dnf install -y nodejs npm
 


### PR DESCRIPTION
Virker som det har skjedd noe med fedora / dns og nodejs
kommandoen "dnf install -y nodejs npm" ser ut til å installere node, men alle node kommandoene feilet med "/usr/bin/node-22: symbol lookup error: /lib64/libnode.so.127: undefined symbol: sqlite3session_attach"

oppdatering av node source så ut til å løse problemet

Bygg playwright-runner: latest hver natt slik at vi alltid har oppdatert playwright med oppdaterte nettlesere
