### PR TITLE
VA-289: lås playwright-versjon til 1.x.x

### DIFF
--- a/playwright/Containerfile
+++ b/playwright/Containerfile
@@ -23,7 +23,7 @@ RUN dnf install -y \
 
 # Install Playwright
 RUN npm init -y && \
-    npm install -g playwright
+    npm install -g playwright@1
 
 # Set up Playwright browsers directory with correct permissions
 RUN mkdir -p /ms-playwright && \


### PR DESCRIPTION
Låser playwright versjon til 1, slik at det som installeres i denne
runneren spiller på lag med det som er installert i
ende-til-ende-test-prosjektene i monorepo, som
per i dag bruker versjonsrange ^1.x.x når de installerer
@playwright/test.

@playwright/test og playwright må ende med å kjøre i samme versjon når
tester kjører i denne containeren, da filstien til browseren som
playwright forsøker å kjøre inneholder et løpenummer som er spesifikt
for versjonen av pakken playwright som er installert

VA-289