### PR TITLE
Plattform-3233 fiks image build

### DIFF
--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -19,12 +19,13 @@ RUN dnf -y upgrade --security && \
     python3-winrm && \
     dnf clean all
 
-RUN curl -fsSL https://dlcdn.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz -o apache-maven-3.9.16-bin.tar.gz && \
-    file apache-maven-3.9.16-bin.tar.gz && \
-    tar xzf apache-maven-3.9.16-bin.tar.gz -C /opt && \
-    rm apache-maven-3.9.16-bin.tar.gz
+ARG MAVEN_VERSION=3.9.16
+RUN curl -fsSL https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz -o apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    file apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    tar xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt && \
+    rm apache-maven-${MAVEN_VERSION}-bin.tar.gz
 ENV JAVA_HOME=/usr/lib/jvm/java
-RUN sudo ln -s /opt/apache-maven-3.9.16/bin/mvn /usr/local/bin/mvn
+RUN sudo ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 RUN mvn -version
 
 RUN sudo chmod 4711 /usr/bin/ping

--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -21,7 +21,6 @@ RUN dnf -y upgrade --security && \
 
 ARG MAVEN_VERSION=3.9.16
 RUN curl -fsSL https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz -o apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
-    file apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     tar xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt && \
     rm apache-maven-${MAVEN_VERSION}-bin.tar.gz
 ENV JAVA_HOME=/usr/lib/jvm/java

--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -23,9 +23,8 @@ RUN curl -fsSL https://dlcdn.apache.org/maven/maven-3/3.9.16/binaries/apache-mav
     file apache-maven-3.9.16-bin.tar.gz && \
     tar xzf apache-maven-3.9.16-bin.tar.gz -C /opt && \
     rm apache-maven-3.9.16-bin.tar.gz
-RUN tar xzf apache-maven-3.9.14-bin.tar.gz -C /opt
 ENV JAVA_HOME=/usr/lib/jvm/java
-RUN sudo ln -s /opt/apache-maven-3.9.14/bin/mvn /usr/local/bin/mvn
+RUN sudo ln -s /opt/apache-maven-3.9.16/bin/mvn /usr/local/bin/mvn
 RUN mvn -version
 
 RUN sudo chmod 4711 /usr/bin/ping

--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -19,7 +19,10 @@ RUN dnf -y upgrade --security && \
     python3-winrm && \
     dnf clean all
 
-RUN curl -LO https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz
+RUN curl -fsSL https://dlcdn.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz -o apache-maven-3.9.16-bin.tar.gz && \
+    file apache-maven-3.9.16-bin.tar.gz && \
+    tar xzf apache-maven-3.9.16-bin.tar.gz -C /opt && \
+    rm apache-maven-3.9.16-bin.tar.gz
 RUN tar xzf apache-maven-3.9.14-bin.tar.gz -C /opt
 ENV JAVA_HOME=/usr/lib/jvm/java
 RUN sudo ln -s /opt/apache-maven-3.9.14/bin/mvn /usr/local/bin/mvn

--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -24,7 +24,7 @@ RUN curl -fsSL https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/
     tar xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt && \
     rm apache-maven-${MAVEN_VERSION}-bin.tar.gz
 ENV JAVA_HOME=/usr/lib/jvm/java
-RUN sudo ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
+RUN sudo ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 RUN mvn -version
 
 RUN sudo chmod 4711 /usr/bin/ping


### PR DESCRIPTION
Workflowen feiler:
https://github.com/domstolene/openshift-actions-runners/actions/runs/30862645366/job/91847746314?pr=28

Antagelig fordi versjonen ikke lengre finnes på dlcdn. Denne PRen oppdatere versjonen og forbedre containerfile generell