### PR TITLE
PLATTFORM-3233-fiks-etter-fedora-update

### DIFF
--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -13,9 +13,8 @@ RUN dnf -y upgrade --security && \
     iputils \
     samba-client \
     wget \
-    unzip \
     gettext-envsubst \
-    java-21-openjdk-devel \
+    java-25-openjdk-devel \
     python3-winrm && \
     dnf clean all
 

--- a/java/Containerfile
+++ b/java/Containerfile
@@ -3,6 +3,6 @@ FROM $BASE_IMG AS java-runner
 
 USER root
 
-RUN dnf install -y java-21-openjdk-devel.x86_64
+RUN dnf install -y java-25-openjdk-devel.x86_64
 
 USER $UID


### PR DESCRIPTION
Build image feiler https://github.com/domstolene/openshift-actions-runners/actions/runs/31597976127/job/94118066622
pga av `No match for argument: java-21-openjdk-devel`
Oppdatere package og fjernet unzip siden den er allerede en del av fedora image (`Package "unzip-6.0-69.fc44.x86_64" is already installed`)